### PR TITLE
demo: ShortcutEditor: Fix broken call GetMenuBar()

### DIFF
--- a/demo/agw/ShortcutEditor.py
+++ b/demo/agw/ShortcutEditor.py
@@ -327,7 +327,7 @@ class ShortcutEditorDemo(wx.Frame):
     def OnMenuShortcuts(self, event):
 
         itemId = event.GetId()
-        menu = event.GetEventObject().GetMenuBar()
+        menu = event.GetEventObject()
         menuItem = menu.FindItemById(itemId)
 
         label = menuItem.GetItemLabel()


### PR DESCRIPTION
Fixes [ShortcutEditor demo] such that it doesn't crash with a traceback when pressing the menu key combination defined in the editor.

**Operating system**: macOS 10.14.6, Windows 7
**wxPython version & source**: wxPython 4.1.1, from PyPI
**Python version & source**: Python 3.8.10

Repro Steps:
* Run [ShortcutEditor demo].
* A "Configure Keyboard Shortcuts" dialog appears.
* Look for an easy-to-type shortcut that was randomly generated for one of the menuitems. For example, I see "FileItem 2" is bound to Ctrl-H.
* If on Windows, click the gray frame that appeared behind the main "wxPython: (A demonstration)" window. If on macOS, the grey frame should already be frontmost.
* Press OK in the dialog to close it.
* Press the shortcut (ex: Ctrl-H) to trigger it.

Expected Results:
* Demo Log Messages shows new message: "You have selected the shortcut for FileItem 2 (Ctrl+H)"

Actual Results:
* Terminal (in macOS) shows the traceback:

```
Traceback (most recent call last):
  File "agw/ShortcutEditor.py", line 330, in OnMenuShortcuts
    menu = event.GetEventObject().GetMenuBar()
AttributeError: 'Menu' object has no attribute 'GetMenuBar'
```

[ShortcutEditor demo]: https://github.com/wxWidgets/Phoenix/blob/33cabe97b7fbd774e58e2f03d4446bd35476fc40/demo/agw/ShortcutEditor.py